### PR TITLE
Add padding to filenames indices

### DIFF
--- a/donkeycar/parts/datastore.py
+++ b/donkeycar/parts/datastore.py
@@ -204,7 +204,7 @@ class Tub(object):
         def get_file_ix(file_name):
             try:
                 name = file_name.split('.')[0]
-                num = int(name.split('_')[1])
+                num = int(name.split('_')[1].lstrip('0'))
             except:
                 num = 0
             return num
@@ -330,7 +330,8 @@ class Tub(object):
 
 
     def get_json_record_path(self, ix):
-        return os.path.join(self.path, 'record_'+str(ix)+'.json')
+        filename = 'record_{:05d}.json'.format(ix)
+        return os.path.join(self.path, filename)
 
     def get_json_record(self, ix):
         path = self.get_json_record_path(ix)
@@ -374,8 +375,8 @@ class Tub(object):
 
 
     def make_file_name(self, key, ext='.png'):
-        name = '_'.join([str(self.current_ix), key, ext])
-        name = name = name.replace('/', '-')
+        name = '{:05d}_{}{}'.format(self.current_ix, key, ext)
+        name = name.replace('/', '-')
         return name
 
     def delete(self):


### PR DESCRIPTION
Closes #1  Each filename has an index, previously written as a simple integer, for
example 1, 2, .. 10, 11, etc, which was annoying for viewing and parsing
with certain tools.  These are now converted to 5-wide padded indices,
for example 00001, 00002, .. 00010, 00011, etc.
